### PR TITLE
Add OAuth state validation and tests

### DIFF
--- a/__tests__/server.test.js
+++ b/__tests__/server.test.js
@@ -1,0 +1,103 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const http = require('http');
+const { createServer } = require('../backend/server');
+
+async function startServer(exchangeCode) {
+  const server = createServer({ exchangeCode });
+  await new Promise((resolve) => server.listen(0, resolve));
+  const address = server.address();
+  return { server, port: address.port };
+}
+
+async function stopServer(server) {
+  await new Promise((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+}
+
+function httpRequest(port, path, { headers } = {}) {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        hostname: '127.0.0.1',
+        port,
+        path,
+        method: 'GET',
+        headers,
+      },
+      (res) => {
+        const chunks = [];
+        res.on('data', (chunk) => chunks.push(chunk));
+        res.on('end', () => {
+          resolve({
+            status: res.statusCode,
+            headers: res.headers,
+            body: Buffer.concat(chunks).toString('utf8'),
+          });
+        });
+      },
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+test('successfully exchanges tokens when state matches', async () => {
+  let exchangeCount = 0;
+  const tokens = { access_token: 'token123' };
+  const exchangeCode = async () => {
+    exchangeCount += 1;
+    return tokens;
+  };
+
+  const { server, port } = await startServer(exchangeCode);
+  try {
+    const startResponse = await httpRequest(port, '/auth/twitch');
+    assert.strictEqual(startResponse.status, 302);
+    const state = new URL(startResponse.headers.location).searchParams.get('state');
+    assert.match(state, /^[0-9a-f]{32}$/);
+
+    const cookieHeader = startResponse.headers['set-cookie'][0].split(';')[0];
+    const callbackPath = `/auth/twitch/callback?state=${state}&code=valid-code`;
+    const callbackResponse = await httpRequest(port, callbackPath, {
+      headers: { Cookie: cookieHeader },
+    });
+
+    assert.strictEqual(callbackResponse.status, 200);
+    assert.deepStrictEqual(JSON.parse(callbackResponse.body), {
+      provider: 'twitch',
+      tokens,
+    });
+    assert.strictEqual(exchangeCount, 1);
+  } finally {
+    await stopServer(server);
+  }
+});
+
+test('rejects tampered state and skips token exchange', async () => {
+  let exchangeCount = 0;
+  const exchangeCode = async () => {
+    exchangeCount += 1;
+    return {};
+  };
+
+  const { server, port } = await startServer(exchangeCode);
+  try {
+    const startResponse = await httpRequest(port, '/auth/twitch');
+    assert.strictEqual(startResponse.status, 302);
+
+    const cookieHeader = startResponse.headers['set-cookie'][0].split(';')[0];
+    const callbackPath = `/auth/twitch/callback?state=tampered&code=valid-code`;
+    const callbackResponse = await httpRequest(port, callbackPath, {
+      headers: { Cookie: cookieHeader },
+    });
+
+    assert.strictEqual(callbackResponse.status, 400);
+    const body = JSON.parse(callbackResponse.body);
+    assert.strictEqual(body.error, 'invalid_oauth_state');
+    assert.strictEqual(exchangeCount, 0);
+  } finally {
+    await stopServer(server);
+  }
+});

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,198 @@
+const http = require('http');
+const crypto = require('crypto');
+
+const providers = {
+  twitch: {
+    authorizeUrl: 'https://id.twitch.tv/oauth2/authorize',
+    tokenUrl: 'https://id.twitch.tv/oauth2/token',
+    scope: process.env.TWITCH_SCOPE || 'user:read:email',
+    clientId: process.env.TWITCH_CLIENT_ID || 'twitch-client-id',
+    clientSecret: process.env.TWITCH_CLIENT_SECRET || 'twitch-client-secret',
+    redirectUri:
+      process.env.TWITCH_REDIRECT_URI || 'http://localhost:3000/auth/twitch/callback',
+  },
+  youtube: {
+    authorizeUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+    tokenUrl: 'https://oauth2.googleapis.com/token',
+    scope:
+      process.env.YOUTUBE_SCOPE || 'https://www.googleapis.com/auth/youtube.readonly',
+    clientId: process.env.YOUTUBE_CLIENT_ID || 'youtube-client-id',
+    clientSecret: process.env.YOUTUBE_CLIENT_SECRET || 'youtube-client-secret',
+    redirectUri:
+      process.env.YOUTUBE_REDIRECT_URI || 'http://localhost:3000/auth/youtube/callback',
+  },
+  streamlabs: {
+    authorizeUrl: 'https://streamlabs.com/api/v2.0/authorize',
+    tokenUrl: 'https://streamlabs.com/api/v2.0/token',
+    scope: process.env.STREAMLABS_SCOPE || 'read donations',
+    clientId: process.env.STREAMLABS_CLIENT_ID || 'streamlabs-client-id',
+    clientSecret:
+      process.env.STREAMLABS_CLIENT_SECRET || 'streamlabs-client-secret',
+    redirectUri:
+      process.env.STREAMLABS_REDIRECT_URI ||
+      'http://localhost:3000/auth/streamlabs/callback',
+  },
+};
+
+function generateState(randomBytes = crypto.randomBytes) {
+  return randomBytes(16).toString('hex');
+}
+
+function buildAuthorizeUrl(config, state) {
+  const params = new URLSearchParams({
+    response_type: 'code',
+    client_id: config.clientId,
+    redirect_uri: config.redirectUri,
+    scope: config.scope,
+    state,
+  });
+  return `${config.authorizeUrl}?${params.toString()}`;
+}
+
+function parseCookies(header = '') {
+  return header.split(';').reduce((acc, cookie) => {
+    const [name, ...rest] = cookie.trim().split('=');
+    if (!name) {
+      return acc;
+    }
+    acc[name] = decodeURIComponent(rest.join('='));
+    return acc;
+  }, {});
+}
+
+function serializeCookie(name, value) {
+  const attributes = ['HttpOnly', 'SameSite=Lax', 'Path=/'];
+  return `${name}=${encodeURIComponent(value)}; ${attributes.join('; ')}`;
+}
+
+async function defaultExchangeCode(config, code) {
+  const body = new URLSearchParams({
+    client_id: config.clientId,
+    client_secret: config.clientSecret,
+    redirect_uri: config.redirectUri,
+    grant_type: 'authorization_code',
+    code,
+  });
+
+  const response = await fetch(config.tokenUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body,
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    const error = new Error('Token exchange failed');
+    error.status = response.status;
+    error.responseBody = text;
+    throw error;
+  }
+
+  return response.json();
+}
+
+function createSession(sessionStore, sessionId) {
+  if (!sessionStore.has(sessionId)) {
+    sessionStore.set(sessionId, { oauthStates: {} });
+  }
+  return sessionStore.get(sessionId);
+}
+
+function createServer({ exchangeCode = defaultExchangeCode } = {}) {
+  const sessionStore = new Map();
+
+  const server = http.createServer(async (req, res) => {
+    try {
+      const url = new URL(req.url, 'http://localhost');
+      const cookies = parseCookies(req.headers.cookie);
+      let sessionId = cookies.sid;
+
+      if (!sessionId || !sessionStore.has(sessionId)) {
+        sessionId = crypto.randomBytes(18).toString('hex');
+      }
+
+      const session = createSession(sessionStore, sessionId);
+      const setCookie = serializeCookie('sid', sessionId);
+
+      const startMatch = url.pathname.match(/^\/auth\/(twitch|youtube|streamlabs)$/);
+      const callbackMatch = url.pathname.match(
+        /^\/auth\/(twitch|youtube|streamlabs)\/callback$/,
+      );
+
+      if (startMatch) {
+        const provider = startMatch[1];
+        const config = providers[provider];
+        const state = generateState();
+        session.oauthStates[provider] = state;
+        const authorizeUrl = buildAuthorizeUrl(config, state);
+        res.statusCode = 302;
+        res.setHeader('Location', authorizeUrl);
+        res.setHeader('Set-Cookie', setCookie);
+        res.end();
+        return;
+      }
+
+      if (callbackMatch) {
+        const provider = callbackMatch[1];
+        const config = providers[provider];
+        const expectedState = session.oauthStates[provider];
+        const state = url.searchParams.get('state');
+        const code = url.searchParams.get('code');
+
+        if (!state || !expectedState || state !== expectedState) {
+          res.statusCode = 400;
+          res.setHeader('Content-Type', 'application/json');
+          res.setHeader('Set-Cookie', setCookie);
+          res.end(
+            JSON.stringify({
+              error: 'invalid_oauth_state',
+              message: 'OAuth state parameter missing or does not match.',
+            }),
+          );
+          return;
+        }
+
+        if (!code) {
+          res.statusCode = 400;
+          res.setHeader('Content-Type', 'application/json');
+          res.setHeader('Set-Cookie', setCookie);
+          res.end(
+            JSON.stringify({
+              error: 'missing_code',
+              message: 'Authorization code missing.',
+            }),
+          );
+          return;
+        }
+
+        delete session.oauthStates[provider];
+        const tokenData = await exchangeCode(config, code);
+        res.statusCode = 200;
+        res.setHeader('Content-Type', 'application/json');
+        res.setHeader('Set-Cookie', setCookie);
+        res.end(JSON.stringify({ provider, tokens: tokenData }));
+        return;
+      }
+
+      res.statusCode = 404;
+      res.setHeader('Set-Cookie', setCookie);
+      res.end('Not Found');
+    } catch (error) {
+      res.statusCode = error.status || 500;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({ error: error.message || 'Internal Server Error' }));
+    }
+  });
+
+  return server;
+}
+
+module.exports = {
+  providers,
+  generateState,
+  buildAuthorizeUrl,
+  parseCookies,
+  serializeCookie,
+  createServer,
+  defaultExchangeCode,
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "m0_alerts",
+  "version": "1.0.0",
+  "private": true,
+  "type": "commonjs",
+  "scripts": {
+    "test": "node --test"
+  }
+}


### PR DESCRIPTION
## Summary
- add an HTTP-based OAuth server that persists per-session state values and appends them to authorize URLs
- validate OAuth callbacks against the stored state before exchanging codes for Twitch, YouTube, and StreamLabs
- cover happy-path and tampered callback flows with node:test integration tests

## Testing
- node --test

------
https://chatgpt.com/codex/tasks/task_e_68ddbb562ad883218158771f121cd8e4